### PR TITLE
Case Sensitive file names for Python

### DIFF
--- a/customer.py
+++ b/customer.py
@@ -1,0 +1,45 @@
+from person import Person
+
+class Customer(Person):
+
+    def __init__(self, name, email, person_id):
+        super().__init__(person_id, name, email) # Using the Person constructor via Super
+        self.order_history = [] 
+
+    def get_role(self):
+        return "Customer"
+
+    @property # Property to alias the person_id as customer_id to make things more readable
+    def customer_id(self):
+        return self.person_id
+
+    def view_order_history(self):
+        return self.order_history
+
+class CustomerManager: # Manages customer objects, customer should not manage itself (SRP)
+    def __init__(self):
+        self.customers = {}
+
+    def create_customer(self, name, email, person_id):
+        if person_id in self.customers:
+            raise ValueError(f"Customer with ID {person_id} already exists.")
+        customer = Customer(name, email, person_id)
+        self.customers[customer.customer_id] = customer
+        return customer
+
+    def get_customer_by_id(self, customer_id):
+        return self.customers.get(customer_id)
+
+    def update_customer(self, customer_id, **kwargs):
+        customer = self.get_customer_by_id(customer_id)
+        if not customer:
+            raise ValueError(f"No customer found with ID {customer_id}")
+        for key, value in kwargs.items():
+            if hasattr(customer, key):
+                setattr(customer, key, value)
+
+    def delete_customer(self, customer_id):
+        if customer_id in self.customers:
+            del self.customers[customer_id]
+        else:
+            raise ValueError(f"No customer found with ID {customer_id}")

--- a/finance.py
+++ b/finance.py
@@ -1,0 +1,3 @@
+class FinancialReport:
+    pass
+    

--- a/person.py
+++ b/person.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod # Abstract Base Class for Person, we will never create a Person directly
+
+class Person(ABC):
+    def __init__(self, person_id, name, email): # Constructor
+        """ Initializes a Person object with name, phone, email, and id."""
+        self.name = name # Attributes
+        self.email = email
+        self.person_id = person_id
+
+    @abstractmethod
+    def get_role(self):
+        """Return the role of the person (e.g., Customer, Supplier)."""
+        pass

--- a/stock.py
+++ b/stock.py
@@ -1,0 +1,8 @@
+class Item:
+    pass
+
+class Inventory:
+    pass
+
+class Order:
+    pass

--- a/supplier.py
+++ b/supplier.py
@@ -1,0 +1,43 @@
+from person import Person
+
+class Supplier(Person):
+
+    def __init__(self, name, email, person_id):
+        super().__init__(person_id, name, email) # Using the Person constructor via Super
+        self.items_supplied = []
+
+    def get_role(self):
+        return "Supplier"
+
+    @property # Property to alias the person_id as supplier_id to make things more readable
+    def supplier_id(self):
+        return self.person_id
+    
+class SupplierManager:
+    def __init__(self):
+        self.suppliers = {}
+
+    def create_supplier(self, name, email, person_id):
+        if person_id in self.suppliers:
+            raise ValueError(f"Supplier with ID {person_id} already exists.")
+        supplier = Supplier(name, email, person_id)
+        self.suppliers[supplier.supplier_id] = supplier
+        return supplier
+
+    def get_supplier_by_id(self, supplier_id):
+        return self.suppliers.get(supplier_id)
+
+    def update_supplier(self, supplier_id, **kwargs):
+        supplier = self.get_supplier_by_id(supplier_id)
+        if not supplier:
+            raise ValueError(f"No supplier found with ID {supplier_id}")
+        for key, value in kwargs.items():
+            if hasattr(supplier, key):
+                setattr(supplier, key, value)
+
+    def delete_supplier(self, supplier_id):
+        if supplier_id in self.suppliers:
+            del self.suppliers[supplier_id]
+        else:
+            raise ValueError(f"No supplier found with ID {supplier_id}")
+

--- a/warehouse.py
+++ b/warehouse.py
@@ -1,0 +1,2 @@
+class Warehouse:
+    pass


### PR DESCRIPTION
Silly bug where local and remote file names do not distinguish their case insensitivity, in main everything is uppercase and locally its not. I've changed the local .git config to ignorecase=false from ignorecase=true which has solved this issue (hopefully)